### PR TITLE
build(ci): auto-merge dependabot PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hseeberger

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: build
+      include: scope
+    cooldown:
+      default-days: 7
+    groups:
+      all:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: ci
+      include: scope
+    cooldown:
+      default-days: 7
+    groups:
+      all:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: build
+      include: scope
+    cooldown:
+      default-days: 7
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,28 @@
+name: Dependabot auto-merge
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  auto-merge:
+    name: Approve and Auto-Merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Approve PR
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh pr review --approve "$PR_URL"
+
+      - name: Enable auto-merge
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
 .git
-.github
 .vscode
 target


### PR DESCRIPTION
## Summary
- Add `.github/workflows/dependabot-auto-merge.yaml`: when a Dependabot PR is opened, the workflow approves it as `github-actions[bot]` (satisfies "Require approvals: 1") and runs `gh pr merge --auto --squash`. Auto-merge fires once required CI checks pass.
- Add `.github/dependabot.yml` (cargo, github-actions, docker — weekly, grouped, with cooldown).
- Add `.github/CODEOWNERS` with `* @hseeberger`.
- Drop `.github` from `.gitignore` so the new files are tracked. The existing `ci.yaml` was grandfathered in despite the rule.

## Test plan
- [ ] Wait for the first Dependabot PR (none today since `dependabot.yml` is new) and verify: workflow runs, approval is recorded, CI passes, PR auto-merges as squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)