### PR TITLE
chore(build): apply common hseeberger project shape

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,8 @@ jobs:
     name: Setup Rust toolchain
     runs-on: ubuntu-latest
     outputs:
-      stable: ${{steps.set_toolchain.outputs.stable}}
-      nightly: ${{steps.set_toolchain.outputs.nightly}}
+      stable: ${{ steps.set_toolchain.outputs.stable }}
+      nightly: ${{ steps.set_toolchain.outputs.nightly }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -50,7 +50,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: ${{needs.toolchain.outputs.nightly}}
+          toolchain: ${{ needs.toolchain.outputs.nightly }}
           components: rustfmt
 
       - name: Install just
@@ -76,7 +76,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: ${{needs.toolchain.outputs.stable}}
+          toolchain: ${{ needs.toolchain.outputs.stable }}
           components: clippy
 
       - name: Install just
@@ -89,7 +89,7 @@ jobs:
 
       - name: just lint
         run: |
-          rustup override set ${{needs.toolchain.outputs.stable}}
+          rustup override set ${{ needs.toolchain.outputs.stable }}
           just lint
 
   test:
@@ -103,7 +103,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          toolchain: ${{needs.toolchain.outputs.stable}}
+          toolchain: ${{ needs.toolchain.outputs.stable }}
 
       - name: Install just
         uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 # v2.75.19
@@ -115,7 +115,7 @@ jobs:
 
       - name: just test
         run: |
-          rustup override set ${{needs.toolchain.outputs.stable}}
+          rustup override set ${{ needs.toolchain.outputs.stable }}
           just test
 
   build-and-push:

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - name: Approve PR
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr review --approve "$PR_URL"
 
       - name: Enable auto-merge
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr merge --auto --squash "$PR_URL"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
-.git
 .vscode
+.zed
 target

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ check:
 	cargo check --tests
 
 fix:
-    cargo fix --allow-dirty --allow-staged --tests
+    cargo fix --tests --allow-dirty --allow-staged
 
 fmt:
     cargo +{{nightly}} fmt
@@ -16,15 +16,18 @@ fmt-check:
     cargo +{{nightly}} fmt --check
 
 lint:
-	cargo clippy --no-deps --tests -- -D warnings
+	cargo clippy --tests --no-deps -- -D warnings
 
 lint-fix:
-    cargo clippy --no-deps --tests --fix --allow-dirty --allow-staged
+    cargo clippy --tests --no-deps --fix --allow-dirty --allow-staged
 
 test:
 	cargo test
 
-all: check fmt lint test
+doc:
+	cargo doc --no-deps
+
+all: check fmt lint test doc
 
 run port="8080":
 	RUST_LOG=hello_rs=debug,api_version=debug,warn \


### PR DESCRIPTION
## Summary

Align with common hseeberger project shape:

- **`.gitignore`**: canonical entries (`.DS_Store`, `.vscode`, `.zed`, `target`); drop redundant `.git`, add missing `.zed`.
- **`justfile`**: put `--tests` first across all recipes (`fix`, `lint`, `lint-fix`); add `doc` recipe and include in `all`.
- **Workflows**: idiomatic spacing inside `${{ ... }}` expressions across `ci.yaml` and `dependabot-auto-merge.yaml`. (Docker `{{version}}` Mustache template left untouched.)

No behavior change.

## Test plan

- [ ] CI passes (lint, fmt-check, test, build-and-push).
- [ ] `just doc` runs locally.