### PR TITLE
ci: add cargo-audit

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,34 @@
+name: Security Audit
+
+permissions:
+  contents: read
+  issues: write
+  checks: write
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Audit Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run cargo-audit
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Add a `Security Audit` workflow that runs `cargo-audit` via [rustsec/audit-check](https://github.com/rustsec/audit-check) (v2.0.0, SHA-pinned). Mirrors the workflow added to api-version (#78).

Triggers:
- **`schedule`** (daily, 06:00 UTC): catches advisories that drop on already-merged dependencies. The action opens a GitHub issue per new advisory.
- **`pull_request`** with `paths` filter on `Cargo.toml` / `Cargo.lock`: fast feedback when a PR introduces a known-vulnerable dep. Posts as a check.
- **`workflow_dispatch`**: manual trigger for testing.

Not added to required status checks — kept advisory for now to avoid false-positive merge blocks; can be promoted later if desired.

## Test plan

- [ ] Workflow appears in Actions tab.
- [ ] Manually run via `workflow_dispatch`; verify it executes against current `Cargo.lock`.
- [ ] On a PR touching `Cargo.lock`, the audit check runs.